### PR TITLE
Add __version__ to __init__.py upon installing

### DIFF
--- a/katversion/__init__.py
+++ b/katversion/__init__.py
@@ -1,1 +1,5 @@
-from version import get_version, build_info
+from .version import get_version, build_info
+from .build import setup
+
+# Get package version when locally imported from repo or via -e develop install
+__version__ = get_version(__path__[0])

--- a/katversion/build.py
+++ b/katversion/build.py
@@ -33,6 +33,7 @@ class AddVersionToInitBuild(DistUtilsBuild):
 
 
 def setup(**kwargs):
+    """Enhanced setuptools.setup that fixes version and does find_packages."""
     # Enforce the version obtained by katversion, overriding user setting
     version = get_version()
     if 'version' in kwargs:

--- a/katversion/build.py
+++ b/katversion/build.py
@@ -1,0 +1,47 @@
+"""Module that customises setuptools to install __version__ inside package."""
+
+import os
+from distutils.command.build import build as DistUtilsBuild
+import warnings
+
+from setuptools import setup as _setup
+from setuptools import find_packages
+
+from .version import get_version
+
+
+class AddVersionToInitBuild(DistUtilsBuild):
+    """Distutils build command that adds __version__ attribute to __init__.py."""
+    def run(self):
+        # First run the normal build procedure
+        DistUtilsBuild.run(self)
+        # Obtain package name and version (set up via setuptools metadata)
+        name = self.distribution.get_name()
+        version = self.distribution.get_version()
+        print "PATH", os.getcwd()
+        # from IPython import embed; embed()
+        # Ensure lib build dir is there (may be absent in script-only packages)
+        module_build_dir = os.path.join(self.build_lib, name)
+        if not os.path.isdir(module_build_dir):
+            os.makedirs(module_build_dir)
+        # Get top-level __init__.py
+        init_py = os.path.join(module_build_dir, "__init__.py")
+        # Append version command to file (create if not there)
+        with open(init_py, 'a') as init_file:
+            init_file.write("\n# Automatically added by katversion\n")
+            init_file.write("__version__ = '{0}'\n".format(version))
+
+
+def setup(**kwargs):
+    # Enforce the version obtained by katversion, overriding user setting
+    version = get_version()
+    if 'version' in kwargs:
+        s = "Ignoring explicit version='{0}' in setup.py, using '{1}' instead"
+        warnings.warn(s.format(kwargs['version'], version))
+    kwargs['version'] = version
+    # Do standard thing to get packages if not specified
+    kwargs['packages'] = kwargs.get('packages', find_packages())
+    # Override build command
+    kwargs['cmdclass'] = {'build': AddVersionToInitBuild}
+    # Now continue with the usual setup
+    return _setup(**kwargs)

--- a/katversion/build.py
+++ b/katversion/build.py
@@ -18,8 +18,6 @@ class AddVersionToInitBuild(DistUtilsBuild):
         # Obtain package name and version (set up via setuptools metadata)
         name = self.distribution.get_name()
         version = self.distribution.get_version()
-        print "PATH", os.getcwd()
-        # from IPython import embed; embed()
         # Ensure lib build dir is there (may be absent in script-only packages)
         module_build_dir = os.path.join(self.build_lib, name)
         if not os.path.isdir(module_build_dir):

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,12 @@
 #!/usr/bin/env python
 
-from setuptools import setup, find_packages
+from katversion import setup
 
-from katversion import get_version
 
 setup(name="katversion",
-      version=get_version(),
       description="Provides versioning for python packages",
       author="MeerKAT CAM Team",
       author_email="cam@ska.ac.za",
-      packages=find_packages(),
       include_package_data=True,
       scripts=["scripts/kat-get-version.py"],
       url='http://ska.ac.za/',


### PR DESCRIPTION
This customises the distutils build command to sneak a \_\_version__ attribute
into a package's top-level \_\_init__.py before installing it. The advantage
is that the version number does not get checked into the repo but remains
in the code itself. It is also hard-coded based on the version of the code
when the package is built, which is more reliable than depending on
pkg_resources matching up the correct package. Additionally, there is only
a build dependency on katversion and not a runtime dependency, so that wheels
can be safely built without requiring installations of katversion everywhere.

In cases where a package is imported locally or via a "setup.py develop"
(aka the "-e" option), katversion.get_version can still be used to get the
current version of the package. This bit of code could be added to the
\_\_init__.py of other packages too (once again with an optional dependency
on katversion):

```
# Get package version when locally imported from repo or via -e develop install
try:
    import katversion as _katversion
except ImportError:
    import time as _time
    __version__ = "0.0+unknown.{}".format(_time.strftime('%Y%m%d%H%M'))
else:
    __version__ = _katversion.get_version(__path__[0])
```

A side benefit is that the setup.py of other packages can simply import
the setup() of katversion, which removes the need for explicit setuptools
imports while dealing with the versioning too.

@theunsa and @martinslabber have obvious interests here...
