### PR TITLE
Fix nosetests by disabling setup() for it

### DIFF
--- a/katversion/build.py
+++ b/katversion/build.py
@@ -32,6 +32,10 @@ class AddVersionToInitBuild(DistUtilsBuild):
 
 def setup(**kwargs):
     """Enhanced setuptools.setup that fixes version and does find_packages."""
+    # Nosetests insists on running module.setup(), so do nothing in that case
+    # The real setup() call will always pass in some kwargs like package name
+    if not kwargs:
+        return
     # Enforce the version obtained by katversion, overriding user setting
     version = get_version()
     if 'version' in kwargs:


### PR DESCRIPTION
Nose insists on calling setup() at the module level to set up any test fixtures
but this calls setuptools instead and fails. Some discussion of this issue is http://stackoverflow.com/questions/23749154. The erroneous nosetests call can
be distinguished from a real setup as the former passes in no kwargs while the
latter will always provide at least e.g. a package name.