### PR TITLE
Replace repo version check

### DIFF
--- a/katversion/__init__.py
+++ b/katversion/__init__.py
@@ -1,5 +1,7 @@
 from .version import get_version, build_info
 from .build import setup
 
+# BEGIN VERSION CHECK
 # Get package version when locally imported from repo or via -e develop install
 __version__ = get_version(__path__[0])
+# END VERSION CHECK


### PR DESCRIPTION
It is nice to have a code block in \__init__.py that finds the repo version of
your package when imported locally or via the develop command (pip -e).

Currently this code still executes and calculates \__version__ before getting
replaced by the hardcoded \__version__. Unfortunately the `get_version()` call
can be quite costly, for example if the package is installed into Homebrew,
which is itself a giant git repository. The `get_version()` call then trundles
merrily through tens of thousands of commits and produces the Homebrew version,
all for nothing (but spends several seconds doing it).

A clean alternative is to mark the repo version code block with sentinels
and then delete it from the edited \__init__.py before appending the new
\__version__. This ensures the fastest possible import.