### PR TITLE
Redo setuptools interaction with entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,12 @@ The format of our version string is:
 Typical usage in `setup.py`:
 
 ```python
-    from katversion import get_version
+    from setuptools import setup
 
     setup(
         ...,
-        version=get_version(),
+        setup_requires=['katversion'],
+        use_katversion=True,
         ...
     )
 ```

--- a/katversion/__init__.py
+++ b/katversion/__init__.py
@@ -1,5 +1,4 @@
 from .version import get_version, build_info
-from .build import setup
 
 # BEGIN VERSION CHECK
 # Get package version when locally imported from repo or via -e develop install

--- a/katversion/build.py
+++ b/katversion/build.py
@@ -4,17 +4,20 @@ import os
 from distutils.command.build import build as DistUtilsBuild
 import warnings
 
-from setuptools import setup as _setup
-from setuptools import find_packages
-
 from .version import get_version
 
 
-class AddVersionToInitBuild(DistUtilsBuild):
+class NewStyleDistUtilsBuild(DistUtilsBuild, object):
+    """Turn old-style distutils class into new-style one."""
+    def run(self):
+        DistUtilsBuild.run(self)
+
+
+class AddVersionToInitBuild(NewStyleDistUtilsBuild):
     """Distutils build command that adds __version__ attribute to __init__.py."""
     def run(self):
         # First run the normal build procedure
-        DistUtilsBuild.run(self)
+        super(NewStyleDistUtilsBuild, self).run()
         # Obtain package name and version (set up via setuptools metadata)
         name = self.distribution.get_name()
         version = self.distribution.get_version()
@@ -41,21 +44,19 @@ class AddVersionToInitBuild(DistUtilsBuild):
             init_file.truncate()
 
 
-def setup(**kwargs):
-    """Enhanced setuptools.setup that fixes version and does find_packages."""
-    # Nosetests insists on running module.setup(), so do nothing in that case
-    # The real setup() call will always pass in some kwargs like package name
-    if not kwargs:
+def setuptools_entry(dist, keyword, value):
+    """Setuptools entry point for setting version and adding it to build."""
+    # If 'use_katversion' is False, ignore the rest
+    if not value:
         return
     # Enforce the version obtained by katversion, overriding user setting
     version = get_version()
-    if 'version' in kwargs:
+    if dist.metadata.version is not None:
         s = "Ignoring explicit version='{0}' in setup.py, using '{1}' instead"
-        warnings.warn(s.format(kwargs['version'], version))
-    kwargs['version'] = version
-    # Do standard thing to get packages if not specified
-    kwargs['packages'] = kwargs.get('packages', find_packages())
-    # Override build command
-    kwargs['cmdclass'] = {'build': AddVersionToInitBuild}
-    # Now continue with the usual setup
-    return _setup(**kwargs)
+        warnings.warn(s.format(dist.metadata.version, version))
+    dist.metadata.version = version
+    # Extend build command to bake version string into installed package
+    ExistingCustomBuild = dist.cmdclass.get('build', object)
+    class FullVersionedBuild(AddVersionToInitBuild, ExistingCustomBuild):
+        """First perform existing build and then bake in version string."""
+    dist.cmdclass['build'] = FullVersionedBuild

--- a/katversion/build.py
+++ b/katversion/build.py
@@ -1,14 +1,14 @@
 """Module that customises setuptools to install __version__ inside package."""
 
 import os
-from distutils.command.build import build as DistUtilsBuild
 import warnings
+from distutils.command.build import build as DistUtilsBuild
 
 from .version import get_version
 
 
 class NewStyleDistUtilsBuild(DistUtilsBuild, object):
-    """Turn old-style distutils class into new-style one."""
+    """Turn old-style distutils class into new-style one to allow extension."""
     def run(self):
         DistUtilsBuild.run(self)
 
@@ -16,7 +16,7 @@ class NewStyleDistUtilsBuild(DistUtilsBuild, object):
 class AddVersionToInitBuild(NewStyleDistUtilsBuild):
     """Distutils build command that adds __version__ attribute to __init__.py."""
     def run(self):
-        # First run the normal build procedure
+        # First do normal build (via super, so this can call custom builds too)
         super(NewStyleDistUtilsBuild, self).run()
         # Obtain package name and version (set up via setuptools metadata)
         name = self.distribution.get_name()

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python
 
-from katversion import setup
+from setuptools import setup, find_packages
+
+from katversion import get_version
+from katversion.build import AddVersionToInitBuild
 
 
 setup(name="katversion",
+      version=get_version(),
       description="Provides versioning for python packages",
       author="MeerKAT CAM Team",
       author_email="cam@ska.ac.za",
@@ -19,6 +23,10 @@ setup(name="katversion",
           "Topic :: Software Development :: Libraries :: Python Modules"],
       platforms=["OS Independent"],
       keywords="meerkat kat ska",
+      packages=find_packages(),
+      entry_points={'distutils.setup_keywords':
+                    'use_katversion = katversion.build:setuptools_entry'},
+      cmdclass={'build': AddVersionToInitBuild},
       tests_require=["unittest2>=0.5.1",
                      "nose>=1.3, <2.0"],
       zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@
 
 from setuptools import setup, find_packages
 
+# These are safe to import inside setup.py as they introduce no external deps
 from katversion import get_version
 from katversion.build import AddVersionToInitBuild
 
 
 setup(name="katversion",
-      version=get_version(),
       description="Provides versioning for python packages",
       author="MeerKAT CAM Team",
       author_email="cam@ska.ac.za",
@@ -24,8 +24,11 @@ setup(name="katversion",
       platforms=["OS Independent"],
       keywords="meerkat kat ska",
       packages=find_packages(),
+      # Register 'use_katversion' keyword for use in participating setup.py files
       entry_points={'distutils.setup_keywords':
                     'use_katversion = katversion.build:setuptools_entry'},
+      # Handle our own version directly instead of via entry point
+      version=get_version(),
       cmdclass={'build': AddVersionToInitBuild},
       tests_require=["unittest2>=0.5.1",
                      "nose>=1.3, <2.0"],


### PR DESCRIPTION
The current solution had one major problem: katversion had to be installed
first in order to simply run setup.py of the package you are installing.
This makes it impossible for pip / setuptools to figure out that your package
actually depends on katversion so that it can be installed automatically.
So 'pip install kattelmod' will never work on a clean system.

The sanctioned way to extend setuptools is via entry points and setup_requires.
The very similar setuptools_scm package serves as inspiration here. The entry
point does two things: use get_version() to set the package version and extend
the build command with the AddVersionToInitBuild class, which bakes the version
string into the built package.

In the case of katversion itself, don't bother eating your own dog food.
While it was trivial in the current solution, the use of entry points requires
you to first run 'python setup.py egg_info' before installing katversion,
as mentioned in setuptools_scm comments. Simply do the two steps of the entry
point explicitly by setting version and cmdclass keywords.

Coincidentally the nosetests problem has also gone away as we do not have
a method called katversion.setup() anymore.
