### PR TITLE
Improve PEP 440 compliance

### DIFF
--- a/katversion/test/test_version.py
+++ b/katversion/test/test_version.py
@@ -13,3 +13,11 @@ class TestVersion(unittest.TestCase):
         for ver, test_verlist in t_ver.items():
             verlist = kv._sane_version_list(ver.split(".", 2))
             self.assertEquals(verlist, test_verlist)
+
+    def test_next_version(self):
+        t_ver = {"v0.1.2": "v0.1.3",
+                 "karoocamv9": "karoocamv10",
+                 "1.2": "1.3"}
+        for ver, test_nextver in t_ver.items():
+            nextver = kv._next_version(ver)
+            self.assertEquals(nextver, test_nextver)

--- a/scripts/kat-get-version.py
+++ b/scripts/kat-get-version.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Script to get the current version string of a python package."""
+"""Script to get the current version string of a Python package."""
 
 import os
 import argparse

--- a/scripts/kat-get-version.py
+++ b/scripts/kat-get-version.py
@@ -9,9 +9,6 @@ from katversion import get_version
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('-r', '--release', dest='release',
-                        action='store_true', default=False,
-                        help='Show only the short release version.')
     parser.add_argument('-p', '--path', dest='path', action='store',
                         help='Path of SCM checkout. If not given the'
                              ' current directory is used.')
@@ -23,4 +20,4 @@ if __name__ == "__main__":
         # If path was not given us the current working directory. This is the
         # way git smudge uses this file.
         path = os.getcwd()
-    print get_version(path, args.release)
+    print get_version(path)


### PR DESCRIPTION
This does three things:

- Let development versions use the major.minor number of the *next* release.
- Automatically pick a release version if we are sitting on a tagged clean commit.
- Normalise version strings as far as possible (cruddy tags still accepted though).

And some docstring improvements and shuffling.