### PR TITLE
Override sdist command

### DIFF
--- a/katversion/build.py
+++ b/katversion/build.py
@@ -1,10 +1,42 @@
 """Module that customises setuptools to install __version__ inside package."""
 
+import sys
 import os
 import warnings
 from distutils.command.build import build as DistUtilsBuild
+# Ensure we override the correct sdist as setuptools monkey-patches distutils
+if "setuptools" in sys.modules:
+    from setuptools.command.sdist import log, sdist as OriginalSdist
+else:
+    from distutils.command.sdist import log, sdist as OriginalSdist
 
 from .version import get_version
+
+
+def patch_init_py(base_dir, name, version):
+    """Patch __init__.py to remove version check and append hard-coded version."""
+    # Ensure main package dir is there (may be absent in script-only packages)
+    package_dir = os.path.join(base_dir, name)
+    if not os.path.isdir(package_dir):
+        os.makedirs(package_dir)
+    # Open top-level __init__.py and read whole file
+    init_py = os.path.join(package_dir, '__init__.py')
+    log.info("patching %s to bake in version '%s'" % (init_py, version))
+    with open(init_py, 'r+') as init_file:
+        lines = init_file.readlines()
+        # Search for sentinels indicating version checking block
+        try:
+            begin = lines.index("# BEGIN VERSION CHECK\n")
+            end = lines.index("# END VERSION CHECK\n")
+        except ValueError:
+            begin = end = len(lines)
+        # Delete existing repo version checking block in file
+        init_file.seek(0)
+        init_file.writelines(lines[:begin] + lines[end+1:])
+        # Append new version attribute to ensure it is authoritative
+        init_file.write("\n# Automatically added by katversion\n")
+        init_file.write("__version__ = '{0}'\n".format(version))
+        init_file.truncate()
 
 
 class NewStyleDistUtilsBuild(DistUtilsBuild, object):
@@ -21,31 +53,35 @@ class AddVersionToInitBuild(NewStyleDistUtilsBuild):
         # Obtain package name and version (set up via setuptools metadata)
         name = self.distribution.get_name()
         version = self.distribution.get_version()
-        # Ensure lib build dir is there (may be absent in script-only packages)
-        module_build_dir = os.path.join(self.build_lib, name)
-        if not os.path.isdir(module_build_dir):
-            os.makedirs(module_build_dir)
-        # Open top-level __init__.py and read whole file
-        init_py = os.path.join(module_build_dir, "__init__.py")
-        with open(init_py, 'r+') as init_file:
-            lines = init_file.readlines()
-            # Search for sentinels indicating version checking block
-            try:
-                begin = lines.index("# BEGIN VERSION CHECK\n")
-                end = lines.index("# END VERSION CHECK\n")
-            except ValueError:
-                begin = end = len(lines)
-            # Delete existing repo version checking block in file
-            init_file.seek(0)
-            init_file.writelines(lines[:begin] + lines[end+1:])
-            # Append new version attribute to ensure it is authoritative
-            init_file.write("\n# Automatically added by katversion\n")
-            init_file.write("__version__ = '{0}'\n".format(version))
-            init_file.truncate()
+        # Patch (or create) top-level __init__.py
+        patch_init_py(self.build_lib, name, version)
+
+
+class NewStyleSdist(OriginalSdist, object):
+    """Turn old-style distutils class into new-style one to allow extension."""
+    def make_release_tree(self, base_dir, files):
+        OriginalSdist.make_release_tree(self, base_dir, files)
+
+
+class AddVersionToInitSdist(NewStyleSdist):
+    """Distutils sdist command that adds __version__ attribute to __init__.py."""
+    def make_release_tree(self, base_dir, files):
+        # First do normal sdist (via super, so this can call custom sdists too)
+        super(NewStyleSdist, self).make_release_tree(base_dir, files)
+        # Obtain package name and version (set up via setuptools metadata)
+        name = self.distribution.get_name()
+        version = self.distribution.get_version()
+        # Ensure __init__.py is not hard-linked so that we don't change source
+        dest = os.path.join(base_dir, name, '__init__.py')
+        if hasattr(os, 'link') and os.path.exists(dest):
+            os.unlink(dest)
+            self.copy_file(os.path.join(name, '__init__.py'), dest)
+        # Patch (or create) top-level __init__.py
+        patch_init_py(base_dir, name, version)
 
 
 def setuptools_entry(dist, keyword, value):
-    """Setuptools entry point for setting version and adding it to build."""
+    """Setuptools entry point for setting version and adding it to build/sdist."""
     # If 'use_katversion' is False, ignore the rest
     if not value:
         return
@@ -57,6 +93,11 @@ def setuptools_entry(dist, keyword, value):
     dist.metadata.version = version
     # Extend build command to bake version string into installed package
     ExistingCustomBuild = dist.cmdclass.get('build', object)
-    class FullVersionedBuild(AddVersionToInitBuild, ExistingCustomBuild):
+    class KatVersionBuild(AddVersionToInitBuild, ExistingCustomBuild):
         """First perform existing build and then bake in version string."""
-    dist.cmdclass['build'] = FullVersionedBuild
+    dist.cmdclass['build'] = KatVersionBuild
+    # Extend sdist command to bake version string into source package
+    ExistingCustomSdist = dist.cmdclass.get('sdist', object)
+    class KatVersionSdist(AddVersionToInitSdist, ExistingCustomSdist):
+        """First perform existing sdist and then bake in version string."""
+    dist.cmdclass['sdist'] = KatVersionSdist

--- a/katversion/version.py
+++ b/katversion/version.py
@@ -76,10 +76,9 @@ def get_git_version(path=None):
                        '--dirty', '--always')
     git_desc_parts = git_desc.strip().split('-')
 
-    if len(git_desc_parts) == 1:
-        git_desc_parts = [0.0, 0, git_desc_parts[0]]
-    elif len(git_desc_parts) == 2:
-        git_desc_parts = [0.0, 0] + git_desc_parts
+    # If repo contains no tags, start version off at 0.0 (but can't be release)
+    if len(git_desc_parts) < 3:
+        git_desc_parts = ['0.0', '1'] + git_desc_parts
 
     branch_name = run_cmd(path, 'git', 'rev-parse', '--abbrev-ref', 'HEAD')
     branch_name = branch_name.strip().lower()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 # These are safe to import inside setup.py as they introduce no external deps
 from katversion import get_version
-from katversion.build import AddVersionToInitBuild
+from katversion.build import AddVersionToInitBuild, AddVersionToInitSdist
 
 
 setup(name="katversion",
@@ -29,7 +29,8 @@ setup(name="katversion",
                     'use_katversion = katversion.build:setuptools_entry'},
       # Handle our own version directly instead of via entry point
       version=get_version(),
-      cmdclass={'build': AddVersionToInitBuild},
+      cmdclass={'build': AddVersionToInitBuild,
+                'sdist': AddVersionToInitSdist},
       tests_require=["unittest2>=0.5.1",
                      "nose>=1.3, <2.0"],
       zip_safe=False,


### PR DESCRIPTION
The source distribution will be uploaded to PyPI but this currently does not
have the version hard-baked into it. Therefore override the sdist command
in the same way as the build command. Factor out the common patching part.

Also fixes a bug if the repo has no tags.