### PR TITLE
Workaround for older setuptools

### DIFF
--- a/katversion/version.py
+++ b/katversion/version.py
@@ -38,26 +38,6 @@ def run_cmd(path, *cmd):
     return res
 
 
-def normalised(version):
-    """Normalise a version string according to PEP 440, if possible."""
-    if parse_version:
-        # Let setuptools (>= 12) do the normalisation
-        return str(parse_version(version))
-    else:
-        # Homegrown normalisation for older setuptools (< 12)
-        public, sep, local = version.lower().partition('+')
-        # Remove leading 'v' from public version
-        if len(public) >= 2:
-            if public[0] == 'v' and public[1] in '0123456789':
-                public = public[1:]
-        # Turn all characters except alphanumerics into periods in local version
-        alphanum_or_period = ['.'] * 256
-        for c in 'abcdefghijklmnopqrstuvwxyz0123456789':
-            alphanum_or_period[ord(c)] = c
-        local = local.translate(''.join(alphanum_or_period))
-        return public + sep + local
-
-
 def date_version(scm_type=None):
     """Generate a version string based on the SCM type and the date."""
     dt = str(time.strftime('%Y%m%d%H%M'))
@@ -65,7 +45,7 @@ def date_version(scm_type=None):
         version = "0.0+unknown.{0}.{1}".format(scm_type, dt)
     else:
         version = "0.0+unknown." + dt
-    return normalised(version)
+    return version
 
 
 def _next_version(version):
@@ -124,7 +104,7 @@ def get_git_version(path=None):
         version = ("%s.dev%s+%s.%s%s" %
                    (_next_version(release_segment), num_commits_since_branch,
                     branch_name, short_commit_name.lower(), dirty_check))
-    return normalised(version)
+    return version
 
 
 def get_svn_version(path=None):
@@ -193,7 +173,27 @@ def get_version_from_file(path=None):
         with open(filename) as fh:
             version = fh.readline().strip()
             if version:
-                return normalised(version)
+                return version
+
+
+def normalised(version):
+    """Normalise a version string according to PEP 440, if possible."""
+    if parse_version:
+        # Let setuptools (>= 12) do the normalisation
+        return str(parse_version(version))
+    else:
+        # Homegrown normalisation for older setuptools (< 12)
+        public, sep, local = version.lower().partition('+')
+        # Remove leading 'v' from public version
+        if len(public) >= 2:
+            if public[0] == 'v' and public[1] in '0123456789':
+                public = public[1:]
+        # Turn all characters except alphanumerics into periods in local version
+        alphanum_or_period = ['.'] * 256
+        for c in 'abcdefghijklmnopqrstuvwxyz0123456789':
+            alphanum_or_period[ord(c)] = c
+        local = local.translate(''.join(alphanum_or_period))
+        return public + sep + local
 
 
 def get_version(filename=None, module=None):
@@ -240,7 +240,7 @@ def get_version(filename=None, module=None):
     # Check the module.
     version = get_version_from_module(module)
     if version:
-        return version
+        return normalised(version)
 
     path = ''
     if filename:
@@ -256,15 +256,15 @@ def get_version(filename=None, module=None):
     # Check the SCM.
     scm, version = get_version_from_scm(path)
     if version:
-        return version
+        return normalised(version)
 
     # Check if there is a katversion file.
     version = get_version_from_file(path)
     if version:
-        return version
+        return normalised(version)
 
     # None of the above got a version so we will make one up based on the date.
-    return date_version(scm)
+    return normalised(date_version(scm))
 
 
 def _sane_version_list(version):

--- a/katversion/version.py
+++ b/katversion/version.py
@@ -81,6 +81,8 @@ def get_git_version(path=None):
     # If repo contains no tags, start version off at 0.0 (but can't be release)
     if len(git_desc_parts) < 3:
         git_desc_parts = ['0.0', '1'] + git_desc_parts
+        # With no tags 'git describe' prints hash without 'g' in front - add it
+        git_desc_parts[2] = 'g' + git_desc_parts[2]
 
     branch_name = run_cmd(path, 'git', 'rev-parse', '--abbrev-ref', 'HEAD')
     branch_name = branch_name.strip().lower()


### PR DESCRIPTION
A lot of machines (like kat-imager2, etc.) still run ancient setuptools.

In setuptools < 12 the pkg_resources.parse_version function returns
a horrible version tuple that breaks things. In this case do a homegrown
PEP 440 normalisation: strip a leading 'v' from the public version and
ensure that the local version only contains alphanumeric characters
and periods. This should cover most cases of interest derived from
'git describe'.

In addition, make the version string more consistent by always having
a 'g' in front of the commit hash (also in the case of a repo with no tags).

@theunsa @martinslabber, please have a look.