### PR TITLE
Rework git version to use valid version tags only

### DIFF
--- a/katversion/version.py
+++ b/katversion/version.py
@@ -54,8 +54,8 @@ def get_git_version(path=None):
     branch_name = run_cmd(path, 'git', 'rev-parse', '--abbrev-ref', 'HEAD')
     branch_name = branch_name.strip()
     # Determine whether working copy is dirty (i.e. contains modified files)
-    new_and_improved_files = run_cmd(path, 'git', 'status', '--porcelain')
-    dirty = '.dirty' if new_and_improved_files else ''
+    mods = run_cmd(path, 'git', 'status', '--porcelain', '--untracked-files=no')
+    dirty = '.dirty' if mods else ''
     # Get a list of all commits on branch, with corresponding branch/tag refs
     # Each line looks something like: "d3e4d42 (HEAD, master, tag: v0.1)"
     git_output = run_cmd(path, 'git', 'log', '--pretty="%h%d"')


### PR DESCRIPTION
The previous iteration accepted any tag as the version, leading to some
nonsensical version numbers (as normalisation is only done loosely).

Instead, replace the use of 'git describe' with a 'git log' incantation
that finds all tags in the current branch. This allows the routine to
search for the latest valid version tag (and use 0.0 if none was found).
This decouples the use of tags for releases from other potential use cases
and also enforces normalisation in the main version number.

In the absence of 'git describe', use 'git status --porcelain' to determine
dirtyness. There is no need for 'git rev-list' as 'git log' subsumes this
('rev-list' could also have done a 'log' but is slightly more cumbersome).
Since we are checking version number validity in get_git_version(), the
functionality of _next_version() is now included here for convenience.