### PR TITLE
Fix pip sdist installs

### DIFF
--- a/katversion/build.py
+++ b/katversion/build.py
@@ -49,9 +49,12 @@ def patch_init_py(base_dir, name, version):
         # Delete existing repo version checking block in file
         init_file.seek(0)
         init_file.writelines(lines[:begin] + lines[end+1:])
-        # Append new version attribute to ensure it is authoritative
-        init_file.write("\n# Automatically added by katversion\n")
-        init_file.write("__version__ = '{0}'\n".format(version))
+        # Append new version attribute to ensure it is authoritative, but only
+        # if it is not already there (this happens in pip sdist installs)
+        version_cmd = "__version__ = '{0}'\n".format(version)
+        if lines[-1] != version_cmd:
+            init_file.write("\n# Automatically added by katversion\n")
+            init_file.write(version_cmd)
         init_file.truncate()
 
 

--- a/katversion/version.py
+++ b/katversion/version.py
@@ -27,6 +27,7 @@ try:
     from pkg_resources import parse_version, SetuptoolsVersion
 except ImportError:
     parse_version = SetuptoolsVersion = None
+from pkginfo import UnpackedSDist
 
 
 VERSION_FILE = '___version___'
@@ -158,6 +159,15 @@ def get_version_from_module(module):
             pass
 
 
+def get_version_from_unpacked_sdist(path):
+    """Assume path points to an unpacked source distribution and get version."""
+    try:
+        return UnpackedSDist(path).version
+    except ValueError:
+        # Could not load path as an unpacked sdist
+        pass
+
+
 def get_version_from_file(path):
     """Find the VERSION_FILE and return its contents.
 
@@ -256,6 +266,11 @@ def get_version(path=None, module=None):
         path = os.path.dirname(path)
     if not os.path.isdir(path):
         raise ValueError('No such package source directory: %r' % (path,))
+
+    # Check for an sdist in the process of being installed by pip.
+    version = get_version_from_unpacked_sdist(path)
+    if version:
+        return normalised(version)
 
     # Check the SCM.
     scm, version = get_version_from_scm(path)

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,14 @@
 # limitations under the License.
 ################################################################################
 
-from setuptools import setup, find_packages
+from setuptools import dist, setup, find_packages
 
-# These are safe to import inside setup.py as they introduce no external deps
+# Ensure we have pkginfo before we start as it is needed before we call setup()
+# If not installed system-wide it will be downloaded into the local .eggs dir
+dist.Distribution(dict(setup_requires='pkginfo'))
+
+# These are safe to import inside setup.py as the only external dependencies
+# are setuptools and pkginfo and they are both now available
 from katversion import get_version
 from katversion.build import AddVersionToInitBuildPy, AddVersionToInitSdist
 
@@ -61,6 +66,11 @@ setup(name="katversion",
       version=get_version(),
       cmdclass={'build_py': AddVersionToInitBuildPy,
                 'sdist': AddVersionToInitSdist},
+      # We need pkginfo to get our own version (it will already be there
+      # so this is more for documentation purposes)
+      setup_requires=['pkginfo'],
+      # We also need pkginfo to get the versions of other packages
+      install_requires=['pkginfo'],
       tests_require=["unittest2>=0.5.1",
                      "nose>=1.3, <2.0"],
       zip_safe=False,


### PR DESCRIPTION
When pip installs a source tarball or 'sdist' it actually runs setup.py again,
which then attempts to get the package version from scratch, even though it
is already baked into the package. Since the SCM is not around, things go wrong.
    
This uses the [pkginfo](https://pypi.python.org/pypi/pkginfo) external package to parse the sdist version and use that
instead in this use case. The pkginfo dependency needs special handling as it
is a "pre-setup" requirement for katversion.

It is an important case to fix as anyone without wheel support will get the
sdist from PyPI instead and run into this problem, for katversion and also
for any package that uses it.

Also clean up path handling on the way to this.