### PR TITLE
Prepare for release 0.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,8 @@ Add this to ``setup.py`` (handles installed packages):
             ...
         )
 
-Add this to ``mypackage/__init__.py`` (handles local packages):
+Add this to ``mypackage/__init__.py``, including the comment lines
+(handles local packages):
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -3,13 +3,14 @@ katversion
 
 The *katversion* package provides proper versioning for Python packages as
 dictated by their (git) source repositories. The resulting version string is
-baked into the installed package's __init__.py file for guaranteed traceability.
+baked into the installed package's ``__init__.py`` file for guaranteed
+traceability when imported (no dependency on what pkg_resources thinks!).
 
 Version String Format
 ---------------------
 
 *katversion* generates a version string for your SCM package that
-complies with [PEP 440](https://www.python.org/dev/peps/pep-0440/).
+complies with `PEP 440 <https://www.python.org/dev/peps/pep-0440/>`_.
 It mainly supports git repositories, with a half-hearted attempt at svn support.
 
 The format of our version string is:

--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,16 @@
 katversion
 ==========
 
-Provides proper versioning for Python packages.
+The *katversion* package provides proper versioning for Python packages as
+dictated by their (git) source repositories. The resulting version string is
+baked into the installed package's __init__.py file for guaranteed traceability.
 
-Versioning
-----------
+Version String Format
+---------------------
 
 *katversion* generates a version string for your SCM package that
-complies with [PEP 440] (http://legacy.python.org/dev/peps/pep-0440/).
+complies with [PEP 440](https://www.python.org/dev/peps/pep-0440/).
+It mainly supports git repositories, with a half-hearted attempt at svn support.
 
 The format of our version string is:
 
@@ -41,7 +44,10 @@ The format of our version string is:
 
         $ git tag -a 1.2 -m 'Release version 1.2'
 
-Typical usage in ``setup.py`` (handles installed packages):
+Typical Usage
+-------------
+
+Add this to ``setup.py`` (handles installed packages):
 
 .. code:: python
 
@@ -54,7 +60,7 @@ Typical usage in ``setup.py`` (handles installed packages):
             ...
         )
 
-Typical usage in ``mypackage/__init__.py`` (handles local packages):
+Add this to ``mypackage/__init__.py`` (handles local packages):
 
 .. code:: python
 
@@ -69,7 +75,7 @@ Typical usage in ``mypackage/__init__.py`` (handles local packages):
             __version__ = _katversion.get_version(__path__[0])
         # END VERSION CHECK
 
-Typical usage from command line:
+In addition, a command-line script for checking the version:
 
 ::
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ with open('README.rst') as readme:
     long_description = readme.read()
 
 setup(name="katversion",
-      description="Provides proper versioning for Python packages",
+      description="Reliable git-based versioning for Python packages",
       long_description=long_description,
       author="The MeerKAT CAM Team",
       author_email="cam@ska.ac.za",


### PR DESCRIPTION
This fixes the PEP 440 URL in the docs and adds improvements.

Next step: tag 'v0.6' and upload to PyPI!