### PR TITLE
Safely handle empty __init__ files.

### DIFF
--- a/katversion/build.py
+++ b/katversion/build.py
@@ -52,7 +52,7 @@ def patch_init_py(base_dir, name, version):
         # Append new version attribute to ensure it is authoritative, but only
         # if it is not already there (this happens in pip sdist installs)
         version_cmd = "__version__ = '{0}'\n".format(version)
-        if lines[-1] != version_cmd:
+        if not lines or lines[-1] != version_cmd:
             init_file.write("\n# Automatically added by katversion\n")
             init_file.write(version_cmd)
         init_file.truncate()


### PR DESCRIPTION
On projects that do not yet have all the kat-version entries in the __init__ files a `pip install` breaks.
This small change makes kat-version more robust.