### PR TITLE
Don't depend on pkginfo

### DIFF
--- a/katversion/version.py
+++ b/katversion/version.py
@@ -199,8 +199,8 @@ def get_version_from_unpacked_sdist(path):
     try:
         with open(os.path.join(path, 'PKG-INFO')) as f:
             data = f.read()
-    except Exception as e:
-        # Could not load path as an unpacked sdist
+    except IOError:
+        # Could not load path as an unpacked sdist as it had no PKG-INFO file
         return
     fp = StringIO(_must_decode(data))
     msg = Parser().parse(fp)

--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,10 @@
 # limitations under the License.
 ################################################################################
 
-from setuptools import dist, setup, find_packages
+from setuptools import setup, find_packages
 
-# Ensure we have pkginfo before we start as it is needed before we call setup()
-# If not installed system-wide it will be downloaded into the local .eggs dir
-dist.Distribution(dict(setup_requires='pkginfo'))
-
-# These are safe to import inside setup.py as the only external dependencies
-# are setuptools and pkginfo and they are both now available
+# These are safe to import inside setup.py as the only external dependency
+# is setuptools and that is already available
 from katversion import get_version
 from katversion.build import AddVersionToInitBuildPy, AddVersionToInitSdist
 
@@ -66,11 +62,6 @@ setup(name="katversion",
       version=get_version(),
       cmdclass={'build_py': AddVersionToInitBuildPy,
                 'sdist': AddVersionToInitSdist},
-      # We need pkginfo to get our own version (it will already be there
-      # so this is more for documentation purposes)
-      setup_requires=['pkginfo'],
-      # We also need pkginfo to get the versions of other packages
-      install_requires=['pkginfo'],
       tests_require=["unittest2>=0.5.1",
                      "nose>=1.3, <2.0"],
       zip_safe=False,


### PR DESCRIPTION
This is just not worth it...

  - Having a "pre-setup" requirement is just a pain
  - We only need it to read a single number from the PKG-INFO file
  - This functionality only arrived in pkginfo 1.1b1, causing problems for katversion even on Ubuntu 14.04

I therefore extracted the relevant code from pkginfo 1.4.1, condensed it substantially and got rid of the dependency.

This hopefully addresses both issues #24 and #25.