### PR TITLE
Support basic pre-release versions

### DIFF
--- a/katversion/test/test_version.py
+++ b/katversion/test/test_version.py
@@ -24,6 +24,7 @@ class TestVersion(unittest.TestCase):
 
     def test_sane_version(self):
         t_ver = {"v0.1.2": [0, 1, '2'],
+                 "v1.0a1": [1, 0, '0a1'],
                  "99.88.dev1234+345.678": [99, 88, "dev1234+345.678"],
                  "foo.bar": [0, 0, "foo", "bar"]}
         for ver, test_verlist in t_ver.items():


### PR DESCRIPTION
Preserve any non-digit text at the end of the version string, since this frequently indicates a pre-release version like '1.0a1' or
'1.0rc3'. This is the bare minimum to make pre-release versions work.

Yes, we probably could use the `semver` package or even switch to `setuptools_scm` :-D